### PR TITLE
New removable interceptors API.

### DIFF
--- a/Alamofire/NetAlamofire.swift
+++ b/Alamofire/NetAlamofire.swift
@@ -84,9 +84,10 @@ open class NetAlamofire: Net {
     }
 
     open func removeInterceptor(_ token: InterceptorToken) -> Bool {
-        var removed = requestInterceptors.removeValue(forKey: token) != nil
-        removed = responseInterceptors.removeValue(forKey: token) != nil || removed
-        return removed
+        guard requestInterceptors.removeValue(forKey: token) != nil else {
+            return responseInterceptors.removeValue(forKey: token) != nil
+        }
+        return true
     }
 
 }

--- a/Alamofire/NetAlamofire.swift
+++ b/Alamofire/NetAlamofire.swift
@@ -71,19 +71,19 @@ open class NetAlamofire: Net {
         sessionManager = nil
     }
 
-    open func addRequestInterceptor(_ interceptor: @escaping RequestInterceptor) -> InterceptorToken {
+    @discardableResult open func addRequestInterceptor(_ interceptor: @escaping RequestInterceptor) -> InterceptorToken {
         let token = InterceptorToken()
         requestInterceptors[token] = interceptor
         return token
     }
 
-    open func addResponseInterceptor(_ interceptor: @escaping ResponseInterceptor) -> InterceptorToken {
+    @discardableResult open func addResponseInterceptor(_ interceptor: @escaping ResponseInterceptor) -> InterceptorToken {
         let token = InterceptorToken()
         responseInterceptors[token] = interceptor
         return token
     }
 
-    open func removeInterceptor(_ token: InterceptorToken) -> Bool {
+    @discardableResult open func removeInterceptor(_ token: InterceptorToken) -> Bool {
         guard requestInterceptors.removeValue(forKey: token) != nil else {
             return responseInterceptors.removeValue(forKey: token) != nil
         }

--- a/Core/Net.swift
+++ b/Core/Net.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+public typealias InterceptorToken = UUID
+
 public typealias RequestInterceptor = (NetRequest.Builder) -> NetRequest.Builder
 
 public typealias ResponseInterceptor = (NetResponse.Builder) -> NetResponse.Builder
@@ -16,15 +18,13 @@ public protocol Net: class {
 
     static var shared: Net { get }
 
-    var requestInterceptors: [RequestInterceptor] { get set }
-
-    var responseInterceptors: [ResponseInterceptor] { get set }
-
     var retryClosure: NetTask.RetryClosure? { get set }
 
-    func addRequestInterceptor(_ interceptor: @escaping RequestInterceptor)
+    func addRequestInterceptor(_ interceptor: @escaping RequestInterceptor) -> InterceptorToken
 
-    func addResponseInterceptor(_ interceptor: @escaping ResponseInterceptor)
+    func addResponseInterceptor(_ interceptor: @escaping ResponseInterceptor) -> InterceptorToken
+
+    func removeInterceptor(_ token: InterceptorToken) -> Bool
 
     func data(_ request: NetRequest) -> NetTask
 

--- a/Core/Net.swift
+++ b/Core/Net.swift
@@ -20,11 +20,11 @@ public protocol Net: class {
 
     var retryClosure: NetTask.RetryClosure? { get set }
 
-    func addRequestInterceptor(_ interceptor: @escaping RequestInterceptor) -> InterceptorToken
+    @discardableResult func addRequestInterceptor(_ interceptor: @escaping RequestInterceptor) -> InterceptorToken
 
-    func addResponseInterceptor(_ interceptor: @escaping ResponseInterceptor) -> InterceptorToken
+    @discardableResult func addResponseInterceptor(_ interceptor: @escaping ResponseInterceptor) -> InterceptorToken
 
-    func removeInterceptor(_ token: InterceptorToken) -> Bool
+    @discardableResult func removeInterceptor(_ token: InterceptorToken) -> Bool
 
     func data(_ request: NetRequest) -> NetTask
 

--- a/Core/NetTask.swift
+++ b/Core/NetTask.swift
@@ -26,7 +26,10 @@ public protocol NetTaskProtocol: class {
 
 }
 
-open class NetTask {
+open class NetTask: NetTaskProtocol,
+                    Hashable,
+                    CustomStringConvertible,
+                    CustomDebugStringConvertible {
 
     public typealias CompletionClosure = (NetResponse?, NetError?) -> Swift.Void
     public typealias RetryClosure = (NetResponse?, NetError?, UInt) -> Bool
@@ -156,6 +159,8 @@ open class NetTask {
         return self
     }
 
+    // MARK: NetTaskProtocol
+
     @discardableResult open func progress(_ progressClosure: ProgressClosure?) -> Self {
         self.progressClosure = progressClosure
         return self
@@ -190,13 +195,19 @@ open class NetTask {
         netTask?.resume()
     }
 
+    // MARK: Hashable
+
     open var hashValue: Int {
         return identifier.hashValue
     }
 
+    // MARK: Equatable
+
     open static func ==(lhs: NetTask, rhs: NetTask) -> Bool {
         return lhs.identifier == rhs.identifier
     }
+
+    // MARK: CustomStringConvertible
 
     open var description: String {
         var description = String(describing: NetTask.self) + " " + identifier.description + " (" + String(describing: state) + ")"
@@ -206,18 +217,10 @@ open class NetTask {
         return description
     }
 
+    // MARK: CustomDebugStringConvertible
+
     open var debugDescription: String {
         return description
     }
 
 }
-
-extension NetTask: NetTaskProtocol {}
-
-extension NetTask: Hashable {}
-
-extension NetTask: Equatable {}
-
-extension NetTask: CustomStringConvertible {}
-
-extension NetTask: CustomDebugStringConvertible {}

--- a/Stub/NetStub.swift
+++ b/Stub/NetStub.swift
@@ -27,19 +27,19 @@ open class NetStub: Net {
         self.nextResult = nextResult
     }
 
-    open func addRequestInterceptor(_ interceptor: @escaping RequestInterceptor) -> InterceptorToken {
+    @discardableResult open func addRequestInterceptor(_ interceptor: @escaping RequestInterceptor) -> InterceptorToken {
         let token = InterceptorToken()
         requestInterceptors[token] = interceptor
         return token
     }
 
-    open func addResponseInterceptor(_ interceptor: @escaping ResponseInterceptor) -> InterceptorToken {
+    @discardableResult open func addResponseInterceptor(_ interceptor: @escaping ResponseInterceptor) -> InterceptorToken {
         let token = InterceptorToken()
         responseInterceptors[token] = interceptor
         return token
     }
 
-    open func removeInterceptor(_ token: InterceptorToken) -> Bool {
+    @discardableResult open func removeInterceptor(_ token: InterceptorToken) -> Bool {
         guard requestInterceptors.removeValue(forKey: token) != nil else {
             return responseInterceptors.removeValue(forKey: token) != nil
         }

--- a/Stub/NetStub.swift
+++ b/Stub/NetStub.swift
@@ -15,9 +15,9 @@ open class NetStub: Net {
     
     open static var shared: Net = NetStub()
 
-    open var requestInterceptors = [RequestInterceptor]()
+    private var requestInterceptors = [InterceptorToken: RequestInterceptor]()
 
-    open var responseInterceptors = [ResponseInterceptor]()
+    private var responseInterceptors = [InterceptorToken: ResponseInterceptor]()
 
     open var retryClosure: NetTask.RetryClosure?
 
@@ -27,20 +27,31 @@ open class NetStub: Net {
         self.nextResult = nextResult
     }
 
-    open func addRequestInterceptor(_ interceptor: @escaping RequestInterceptor) {
-        requestInterceptors.append(interceptor)
+    open func addRequestInterceptor(_ interceptor: @escaping RequestInterceptor) -> InterceptorToken {
+        let token = InterceptorToken()
+        requestInterceptors[token] = interceptor
+        return token
     }
 
-    open func addResponseInterceptor(_ interceptor: @escaping ResponseInterceptor) {
-        responseInterceptors.append(interceptor)
+    open func addResponseInterceptor(_ interceptor: @escaping ResponseInterceptor) -> InterceptorToken {
+        let token = InterceptorToken()
+        responseInterceptors[token] = interceptor
+        return token
+    }
+
+    open func removeInterceptor(_ token: InterceptorToken) -> Bool {
+        var removed = requestInterceptors.removeValue(forKey: token) != nil
+        removed = responseInterceptors.removeValue(forKey: token) != nil || removed
+        return removed
     }
 
     func stub(_ request: NetRequest? = nil) -> NetTask {
         var requestBuilder = request?.builder()
-        if let builder = requestBuilder {
-            requestInterceptors.forEach { interceptor in
-                requestBuilder = interceptor(builder)
+        if var builder = requestBuilder {
+            requestInterceptors.values.forEach { interceptor in
+                builder = interceptor(builder)
             }
+            requestBuilder = builder
         }
         guard let nextResult = nextResult else {
             return NetTaskStub(request: requestBuilder?.build())
@@ -48,7 +59,7 @@ open class NetStub: Net {
         switch nextResult {
         case .response(let response):
             var responseBuilder = response.builder()
-            responseInterceptors.forEach { interceptor in
+            responseInterceptors.values.forEach { interceptor in
                 responseBuilder = interceptor(responseBuilder)
             }
             return NetTaskStub(request: requestBuilder?.build(), response: responseBuilder.build())

--- a/Stub/NetStub.swift
+++ b/Stub/NetStub.swift
@@ -40,9 +40,10 @@ open class NetStub: Net {
     }
 
     open func removeInterceptor(_ token: InterceptorToken) -> Bool {
-        var removed = requestInterceptors.removeValue(forKey: token) != nil
-        removed = responseInterceptors.removeValue(forKey: token) != nil || removed
-        return removed
+        guard requestInterceptors.removeValue(forKey: token) != nil else {
+            return responseInterceptors.removeValue(forKey: token) != nil
+        }
+        return true
     }
 
     func stub(_ request: NetRequest? = nil) -> NetTask {

--- a/Stub/NetTaskStub.swift
+++ b/Stub/NetTaskStub.swift
@@ -12,6 +12,10 @@ class NetTaskStub: NetTask {
     override func async(_ completion: NetTask.CompletionClosure?) -> Self {
         completionClosure = completion
         progressClosure?(Progress(totalUnitCount: 0))
+        guard let response = response else {
+            completion?(nil, error ?? .net(code: nil, message: "Next result not specified.", headers: nil, object: nil, underlying: nil))
+            return self
+        }
         completion?(response, error)
         return self
     }

--- a/URLSession/NetURLSession.swift
+++ b/URLSession/NetURLSession.swift
@@ -91,9 +91,10 @@ open class NetURLSession: Net {
     }
 
     open func removeInterceptor(_ token: InterceptorToken) -> Bool {
-        var removed = requestInterceptors.removeValue(forKey: token) != nil
-        removed = responseInterceptors.removeValue(forKey: token) != nil || removed
-        return removed
+        guard requestInterceptors.removeValue(forKey: token) != nil else {
+            return responseInterceptors.removeValue(forKey: token) != nil
+        }
+        return true
     }
 
     deinit {

--- a/URLSession/NetURLSession.swift
+++ b/URLSession/NetURLSession.swift
@@ -78,19 +78,19 @@ open class NetURLSession: Net {
         serverTrust = serverTrustPolicies
     }
 
-    open func addRequestInterceptor(_ interceptor: @escaping RequestInterceptor) -> InterceptorToken {
+    @discardableResult open func addRequestInterceptor(_ interceptor: @escaping RequestInterceptor) -> InterceptorToken {
         let token = InterceptorToken()
         requestInterceptors[token] = interceptor
         return token
     }
 
-    open func addResponseInterceptor(_ interceptor: @escaping ResponseInterceptor) -> InterceptorToken {
+    @discardableResult open func addResponseInterceptor(_ interceptor: @escaping ResponseInterceptor) -> InterceptorToken {
         let token = InterceptorToken()
         responseInterceptors[token] = interceptor
         return token
     }
 
-    open func removeInterceptor(_ token: InterceptorToken) -> Bool {
+    @discardableResult open func removeInterceptor(_ token: InterceptorToken) -> Bool {
         guard requestInterceptors.removeValue(forKey: token) != nil else {
             return responseInterceptors.removeValue(forKey: token) != nil
         }

--- a/URLSession/NetURLSession.swift
+++ b/URLSession/NetURLSession.swift
@@ -41,9 +41,9 @@ open class NetURLSession: Net {
         }
     }
 
-    open var requestInterceptors = [RequestInterceptor]()
+    private var requestInterceptors = [InterceptorToken: RequestInterceptor]()
 
-    open var responseInterceptors = [ResponseInterceptor]()
+    private var responseInterceptors = [InterceptorToken: ResponseInterceptor]()
 
     open var retryClosure: NetTask.RetryClosure?
 
@@ -78,12 +78,22 @@ open class NetURLSession: Net {
         serverTrust = serverTrustPolicies
     }
 
-    open func addRequestInterceptor(_ interceptor: @escaping RequestInterceptor) {
-        requestInterceptors.append(interceptor)
+    open func addRequestInterceptor(_ interceptor: @escaping RequestInterceptor) -> InterceptorToken {
+        let token = InterceptorToken()
+        requestInterceptors[token] = interceptor
+        return token
     }
 
-    open func addResponseInterceptor(_ interceptor: @escaping ResponseInterceptor) {
-        responseInterceptors.append(interceptor)
+    open func addResponseInterceptor(_ interceptor: @escaping ResponseInterceptor) -> InterceptorToken {
+        let token = InterceptorToken()
+        responseInterceptors[token] = interceptor
+        return token
+    }
+
+    open func removeInterceptor(_ token: InterceptorToken) -> Bool {
+        var removed = requestInterceptors.removeValue(forKey: token) != nil
+        removed = responseInterceptors.removeValue(forKey: token) != nil || removed
+        return removed
     }
 
     deinit {
@@ -107,7 +117,7 @@ extension NetURLSession {
 
     func urlRequest(_ netRequest: NetRequest) -> URLRequest {
         var builder = netRequest.builder()
-        requestInterceptors.forEach { interceptor in
+        requestInterceptors.values.forEach { interceptor in
             builder = interceptor(builder)
         }
         return builder.build().urlRequest
@@ -139,7 +149,7 @@ extension NetURLSession {
             return nil
         }
         var builder = response.builder()
-        responseInterceptors.forEach { interceptor in
+        responseInterceptors.values.forEach { interceptor in
             builder = interceptor(builder)
         }
         return builder.build()


### PR DESCRIPTION
### Issue Link :link:
https://github.com/intelygenz/NetClient-iOS/pull/11

### Goals :soccer:

Resolve @juantrias issues on https://github.com/intelygenz/NetClient-iOS/pull/11:

---

*[Core/NetTask.swift, line 215 at r1](https://reviewable.io:443/reviews/intelygenz/netclient-ios/11#-L3gUwQtL3-fRqeXaTeF:-L46xiLEPnaxdQ7AkDkh:by6t65n) ([raw file](https://github.com/intelygenz/netclient-ios/blob/4339bf8d45e8187ee60c01b7b7bffd01aab7229d/Core/NetTask.swift#L215)):*
<details><summary><i>Previously, RobertoEstrada (Roberto Estrada) wrote…</i></summary><blockquote>

Actually, reading the style guide, it does not rule nor rule out this edge case so we're in quite an alegal situation. For the moment I'm going to consider this OK but i'm going to propose an exception for cases like this in the style guide.
</blockquote></details>

I agree with @RobertoEstrada. In this case I see no real benefit on declaring protocol conformance in extensions, since this extensions need to be empty because of the problem with open members declared inside extensions https://gitlab.intelygenz.com/daniel.coello/igz-swift-styleguide/issues/4. Maybe we can put `// MARK:` comments to separate the implementation of the different protocols

---

*[Stub/NetStub.swift, line 18 at r1](https://reviewable.io:443/reviews/intelygenz/netclient-ios/11#-L3gG059Y-JFQdxiJk2Q:-L3gG05AHnTGHrGHIwSj:bdibs1e) ([raw file](https://github.com/intelygenz/netclient-ios/blob/4339bf8d45e8187ee60c01b7b7bffd01aab7229d/Stub/NetStub.swift#L18)):*
> ```Swift
>     open static var shared: Net = NetStub()
> 
>     open var requestInterceptors = [RequestInterceptor]()
> ```

Could be `requestInterceptors` and `responseInterceptors` private? I understand that `nextResult` needs to be public because it's the way to mock a response

---

*[Stub/NetStub.swift, line 42 at r1](https://reviewable.io:443/reviews/intelygenz/netclient-ios/11#-L3gHoaNIF3pf0i9NrFl:-L3gHoaNIF3pf0i9NrFm:b-fqp5rn) ([raw file](https://github.com/intelygenz/netclient-ios/blob/4339bf8d45e8187ee60c01b7b7bffd01aab7229d/Stub/NetStub.swift#L42)):*
> ```Swift
>         if let builder = requestBuilder {
>             requestInterceptors.forEach({ interceptor in
>                 requestBuilder = interceptor(builder)
> ```

It seems like you are passing the same `builder` object to each interceptor in the chain, so you are overwriting the `requestBuilder` in each iteration ignoring the result of the previous interceptor

---

*[Stub/NetStub.swift, line 46 at r1](https://reviewable.io:443/reviews/intelygenz/netclient-ios/11#-L3gJ1tlLZNj-iZogfIe:-L3gJ1tlLZNj-iZogfIf:bpwf9v7) ([raw file](https://github.com/intelygenz/netclient-ios/blob/4339bf8d45e8187ee60c01b7b7bffd01aab7229d/Stub/NetStub.swift#L46)):*
> ```Swift
>         }
>         guard let nextResult = nextResult else {
>             return NetTaskStub(request: requestBuilder?.build())
> ```

NetTaskStub.request should be optional? Can we have a NetTask without a request? The `request` parameter of `stub()` should be optional?

---

*[Stub/NetTaskStub.swift, line 10 at r2](https://reviewable.io:443/reviews/intelygenz/netclient-ios/11#-L470mGW0pfijizuHzYU:-L470mGW0pfijizuHzYV:b9u4lgb) ([raw file](https://github.com/intelygenz/netclient-ios/blob/fa0f7d34e73bbc54f0a0da00b414dea176172c02/Stub/NetTaskStub.swift#L10)):*
> ```Swift
> import Foundation
> 
> class NetTaskStub: NetTask {
> ```

Could be NetTaskStub a protocol implementation instead of a NetTask subclass? I generally prefer implement protocols over inheritance for mocks, to clearly separate the mock from the production code and do not end calling by accident production code in the tests. Maybe in this case we need to reuse much of the NetTask code for the Stub and it is OK to inherit, or to place the common code in a NetTask protocol extension

---

*[Stub/NetTaskStub.swift, line 15 at r2](https://reviewable.io:443/reviews/intelygenz/netclient-ios/11#-L4716Ud699f0XZUMZ1Y:-L4716Ud699f0XZUMZ1Z:b-iq313h) ([raw file](https://github.com/intelygenz/netclient-ios/blob/fa0f7d34e73bbc54f0a0da00b414dea176172c02/Stub/NetTaskStub.swift#L15)):*
> ```Swift
>         completionClosure = completion
>         progressClosure?(Progress(totalUnitCount: 0))
>         completion?(response, error)
> ```

If we do not stub `response` or `error` we will call completion block with both params nil. Should we return a "Next result not specified." error like in `sync()`?

---

*[URLSession/NetURLSession.swift, line 11 at r2](https://reviewable.io:443/reviews/intelygenz/netclient-ios/11#-L4AMbQgcQV27BkCAYEW:-L4AMbQgcQV27BkCAYEX:blu0kzh) ([raw file](https://github.com/intelygenz/netclient-ios/blob/fa0f7d34e73bbc54f0a0da00b414dea176172c02/URLSession/NetURLSession.swift#L11)):*
> ```Swift
> import Foundation
> 
> open class NetURLSession: Net {
> ```

Should be open instead of public? Why a client would need to override instead of extend NetURLSession? Same for NetAlamofire and the rest of adapters

---

### Implementation Details 🚧
New removable interceptors API with unique tokens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelygenz/netclient-ios/12)
<!-- Reviewable:end -->
